### PR TITLE
fix don't show notification if -s is provided

### DIFF
--- a/src/dbusservice/dbusscreenshotservice.cpp
+++ b/src/dbusservice/dbusscreenshotservice.cpp
@@ -103,11 +103,11 @@ void DBusScreenshotService::FullscreenScreenshot()
      m_singleInstance = true;
 }
 
-void DBusScreenshotService::SavePathScreenshot(const QString &in0)
+void DBusScreenshotService::SavePathScreenshot(const QString &in0, const bool noNotify)
 {
      qDebug() << "DBus screenshot service! SavePath screenshot";
     // handle method call com.deepin.Screenshot.SavePath
      if (!m_singleInstance)
-        parent()->savePathScreenshot(in0);
+        parent()->savePathScreenshot(in0, noNotify);
      m_singleInstance = true;
 }

--- a/src/dbusservice/dbusscreenshotservice.h
+++ b/src/dbusservice/dbusscreenshotservice.h
@@ -84,7 +84,7 @@ public Q_SLOTS: // METHODS
     void NoNotifyScreenshot();
     void TopWindowScreenshot();
     void FullscreenScreenshot();
-    void SavePathScreenshot(const QString &in0);
+    void SavePathScreenshot(const QString &in0, const bool noNotify);
 Q_SIGNALS: // SIGNALS
 private:
     bool m_singleInstance;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
              w.topWindowScreenshot();
          } else if (cmdParser.isSet(savePathOption)) {
              qDebug() << "cmd savepath screenshot";
-             w.savePathScreenshot(cmdParser.value(savePathOption));
+             w.savePathScreenshot(cmdParser.value(savePathOption), cmdParser.isSet(prohibitNotifyOption));
          } else if (cmdParser.isSet(prohibitNotifyOption)) {
              qDebug() << "screenshot no notify!";
              w.noNotifyScreenshot();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -217,7 +217,10 @@ void MainWindow::initShortcut()
 
 void MainWindow::keyPressEvent(QKeyEvent *keyEvent)
 {
-    if (keyEvent->key() == Qt::Key_Escape ) {
+    if (keyEvent->key() == Qt::Key_Return){
+        // Save screenshot on enter
+        expressSaveScreenshot();
+    }else if (keyEvent->key() == Qt::Key_Escape ) {
         if (m_isShapesWidgetExist) {
             if (m_shapesWidget->textEditIsReadOnly()) {
                 return;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -960,7 +960,7 @@ void MainWindow::fullScreenshot()
     sendNotify(m_saveIndex, m_saveFileName, r);
 }
 
-void MainWindow::savePath(const QString &path)
+void MainWindow::savePath(const QString &path, const bool noNotify)
 {
     if (!QFileInfo(path).dir().exists()) {
         exitApp();
@@ -976,11 +976,11 @@ void MainWindow::savePath(const QString &path)
         emit saveActionTriggered();
         m_needSaveScreenshot = true;
         qDebug() << "toolBar" << m_specificedPath;
-        saveSpecificedPath(m_specificedPath);
+        saveSpecificedPath(m_specificedPath, noNotify);
     });
 }
 
-void MainWindow::saveSpecificedPath(QString path)
+void MainWindow::saveSpecificedPath(QString path, const bool noNotify)
 {
     QString savePath;
     QString baseName = QFileInfo(path).baseName();
@@ -1042,8 +1042,10 @@ void MainWindow::saveSpecificedPath(QString path)
 
     QString summary = QString(tr("Picture has been saved to %1")).arg(savePath);
 
-    m_notifyDBInterface->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
-                                summary, actions, hints, 0);
+    if (!noNotify) {
+        m_notifyDBInterface->Notify("Deepin Screenshot", 0,  "deepin-screenshot", "",
+                                    summary, actions, hints, 0);
+    }
     exitApp();
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -83,8 +83,8 @@ signals:
 
 public slots:
     void fullScreenshot();
-    void savePath(const QString &path);
-    void saveSpecificedPath(QString path);
+    void savePath(const QString &path, const bool noNotify);
+    void saveSpecificedPath(QString path, const bool noNotify);
 //    void delayScreenshot(int num);
     void noNotify();
     void topWindow();

--- a/src/screenshot.cpp
+++ b/src/screenshot.cpp
@@ -89,11 +89,11 @@ void Screenshot::noNotifyScreenshot()
     m_window->noNotify();
 }
 
-void Screenshot::savePathScreenshot(const QString &path)
+void Screenshot::savePathScreenshot(const QString &path, const bool noNotify)
 {
     initUI();
     m_window->show();
-    m_window->savePath(path);
+    m_window->savePath(path, noNotify);
 }
 
 Screenshot::~Screenshot() {}

--- a/src/screenshot.h
+++ b/src/screenshot.h
@@ -35,7 +35,7 @@ public slots:
     void fullscreenScreenshot();
     void topWindowScreenshot();
     void noNotifyScreenshot();
-    void savePathScreenshot(const QString &path);
+    void savePathScreenshot(const QString &path, const bool noNotify);
 
 private:
     void initUI();


### PR DESCRIPTION
If you want to save the screenshot to a specified path (using -s) and don't want to get a notification, -n doesn't work. This is the fix